### PR TITLE
Updates CTR Phoenix library to frc2022

### DIFF
--- a/vendordeps/Phoenix.json
+++ b/vendordeps/Phoenix.json
@@ -1,214 +1,257 @@
 {
-  "fileName": "Phoenix.json",
-  "name": "CTRE-Phoenix",
-  "version": "5.19.4",
-  "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
-  "mavenUrls": [
-    "https://devsite.ctr-electronics.com/maven/release/"
-  ],
-  "jsonUrl": "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/Phoenix-latest.json",
-  "javaDependencies": [
-    {
-      "groupId": "com.ctre.phoenix",
-      "artifactId": "api-java",
-      "version": "5.19.4"
-    },
-    {
-      "groupId": "com.ctre.phoenix",
-      "artifactId": "wpiapi-java",
-      "version": "5.19.4"
-    }
-  ],
-  "jniDependencies": [
-    {
-      "groupId": "com.ctre.phoenix",
-      "artifactId": "cci",
-      "version": "5.19.4",
-      "isJar": false,
-      "skipInvalidPlatforms": true,
-      "validPlatforms": [
-        "linuxathena"
-      ]
-    },
-    {
-      "groupId": "com.ctre.phoenix.sim",
-      "artifactId": "cci-sim",
-      "version": "5.19.4",
-      "isJar": false,
-      "skipInvalidPlatforms": true,
-      "validPlatforms": [
-        "windowsx86-64",
-        "linuxx86-64",
-        "osxx86-64"
-      ]
-    },
-    {
-      "groupId": "com.ctre.phoenix.sim",
-      "artifactId": "simTalonSRX",
-      "version": "5.19.4",
-      "isJar": false,
-      "skipInvalidPlatforms": true,
-      "validPlatforms": [
-        "windowsx86-64",
-        "linuxx86-64",
-        "osxx86-64"
-      ]
-    },
-    {
-      "groupId": "com.ctre.phoenix.sim",
-      "artifactId": "simVictorSPX",
-      "version": "5.19.4",
-      "isJar": false,
-      "skipInvalidPlatforms": true,
-      "validPlatforms": [
-        "windowsx86-64",
-        "linuxx86-64",
-        "osxx86-64"
-      ]
-    }
-  ],
-  "cppDependencies": [
-    {
-      "groupId": "com.ctre.phoenix",
-      "artifactId": "wpiapi-cpp",
-      "version": "5.19.4",
-      "libName": "CTRE_Phoenix_WPI",
-      "headerClassifier": "headers",
-      "sharedLibrary": false,
-      "skipInvalidPlatforms": true,
-      "binaryPlatforms": [
-        "linuxathena",
-        "windowsx86-64",
-        "linuxx86-64",
-        "osxx86-64"
-      ]
-    },
-    {
-      "groupId": "com.ctre.phoenix",
-      "artifactId": "api-cpp",
-      "version": "5.19.4",
-      "libName": "CTRE_Phoenix",
-      "headerClassifier": "headers",
-      "sharedLibrary": false,
-      "skipInvalidPlatforms": true,
-      "binaryPlatforms": [
-        "linuxathena",
-        "windowsx86-64",
-        "linuxx86-64",
-        "osxx86-64"
-      ]
-    },
-    {
-      "groupId": "com.ctre.phoenix",
-      "artifactId": "cci",
-      "version": "5.19.4",
-      "libName": "CTRE_PhoenixCCI",
-      "headerClassifier": "headers",
-      "sharedLibrary": false,
-      "skipInvalidPlatforms": true,
-      "binaryPlatforms": [
-        "linuxathena"
-      ]
-    },
-    {
-      "groupId": "com.ctre.phoenix.sim",
-      "artifactId": "cci-sim",
-      "version": "5.19.4",
-      "libName": "CTRE_PhoenixCCISim",
-      "headerClassifier": "headers",
-      "sharedLibrary": false,
-      "skipInvalidPlatforms": true,
-      "binaryPlatforms": [
-        "windowsx86-64",
-        "linuxx86-64",
-        "osxx86-64"
-      ]
-    },
-    {
-      "groupId": "com.ctre.phoenix",
-      "artifactId": "diagnostics",
-      "version": "5.19.4",
-      "libName": "CTRE_PhoenixDiagnostics",
-      "headerClassifier": "headers",
-      "sharedLibrary": false,
-      "skipInvalidPlatforms": true,
-      "binaryPlatforms": [
-        "linuxathena",
-        "windowsx86-64",
-        "linuxx86-64",
-        "osxx86-64"
-      ]
-    },
-    {
-      "groupId": "com.ctre.phoenix",
-      "artifactId": "canutils",
-      "version": "5.19.4",
-      "libName": "CTRE_PhoenixCanutils",
-      "headerClassifier": "headers",
-      "sharedLibrary": false,
-      "skipInvalidPlatforms": true,
-      "binaryPlatforms": [
-        "windowsx86-64",
-        "linuxx86-64",
-        "osxx86-64"
-      ]
-    },
-    {
-      "groupId": "com.ctre.phoenix",
-      "artifactId": "platform-sim",
-      "version": "5.19.4",
-      "libName": "CTRE_PhoenixPlatform",
-      "headerClassifier": "headers",
-      "sharedLibrary": false,
-      "skipInvalidPlatforms": true,
-      "binaryPlatforms": [
-        "windowsx86-64",
-        "linuxx86-64",
-        "osxx86-64"
-      ]
-    },
-    {
-      "groupId": "com.ctre.phoenix",
-      "artifactId": "core",
-      "version": "5.19.4",
-      "libName": "CTRE_PhoenixCore",
-      "headerClassifier": "headers",
-      "sharedLibrary": false,
-      "skipInvalidPlatforms": true,
-      "binaryPlatforms": [
-        "linuxathena",
-        "windowsx86-64",
-        "linuxx86-64",
-        "osxx86-64"
-      ]
-    },
-    {
-      "groupId": "com.ctre.phoenix.sim",
-      "artifactId": "simTalonSRX",
-      "version": "5.19.4",
-      "libName": "CTRE_SimTalonSRX",
-      "headerClassifier": "headers",
-      "sharedLibrary": true,
-      "skipInvalidPlatforms": true,
-      "binaryPlatforms": [
-        "windowsx86-64",
-        "linuxx86-64",
-        "osxx86-64"
-      ]
-    },
-    {
-      "groupId": "com.ctre.phoenix.sim",
-      "artifactId": "simVictorSPX",
-      "version": "5.19.4",
-      "libName": "CTRE_SimVictorSPX",
-      "headerClassifier": "headers",
-      "sharedLibrary": true,
-      "skipInvalidPlatforms": true,
-      "binaryPlatforms": [
-        "windowsx86-64",
-        "linuxx86-64",
-        "osxx86-64"
-      ]
-    }
-  ]
+    "fileName": "Phoenix.json",
+    "name": "CTRE-Phoenix",
+    "version": "5.21.2",
+    "frcYear": 2022,
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "mavenUrls": [
+        "https://maven.ctr-electronics.com/release/"
+    ],
+    "jsonUrl": "https://maven.ctr-electronics.com/release/com/ctre/phoenix/Phoenix-frc2022-latest.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-java",
+            "version": "5.21.2"
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-java",
+            "version": "5.21.2"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.21.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.21.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonSRX",
+            "version": "5.21.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonFX",
+            "version": "5.21.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simVictorSPX",
+            "version": "5.21.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simPigeonIMU",
+            "version": "5.21.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simCANCoder",
+            "version": "5.21.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-cpp",
+            "version": "5.21.2",
+            "libName": "CTRE_Phoenix_WPI",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-cpp",
+            "version": "5.21.2",
+            "libName": "CTRE_Phoenix",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.21.2",
+            "libName": "CTRE_PhoenixCCI",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "wpiapi-cpp-sim",
+            "version": "5.21.2",
+            "libName": "CTRE_Phoenix_WPISim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "api-cpp-sim",
+            "version": "5.21.2",
+            "libName": "CTRE_PhoenixSim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.21.2",
+            "libName": "CTRE_PhoenixCCISim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonSRX",
+            "version": "5.21.2",
+            "libName": "CTRE_SimTalonSRX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonFX",
+            "version": "5.21.2",
+            "libName": "CTRE_SimTalonFX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simVictorSPX",
+            "version": "5.21.2",
+            "libName": "CTRE_SimVictorSPX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simPigeonIMU",
+            "version": "5.21.2",
+            "libName": "CTRE_SimPigeonIMU",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simCANCoder",
+            "version": "5.21.2",
+            "libName": "CTRE_SimCANCoder",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
This should have been updated when swerve-template was updated to WPI Lib 2022.4.1.